### PR TITLE
[hotfix] fix start.sh not found when use Secure Cloud in Runpod

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -73,10 +73,19 @@ RUN apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Create workspace directory
 RUN mkdir -p /workspace
+RUN mkdir -p /notebooks
 
 # Copy scripts to root
-WORKDIR /workspace
-COPY . .
+WORKDIR /notebooks
+COPY start.sh .
+COPY log_viewer.py . 
+COPY ./workers/* .
+COPY ./utils/* .
+COPY ./static/* . 
+COPY ./dto/* . 
+COPY ./constants/* .
+
+COPY models_config.json /workspace
 
 # Make scripts executable
 RUN chmod +x *.sh

--- a/dockerfile
+++ b/dockerfile
@@ -79,6 +79,7 @@ RUN mkdir -p /notebooks
 WORKDIR /notebooks
 COPY start.sh .
 COPY log_viewer.py . 
+COPY download_models.py .
 COPY ./workers/* .
 COPY ./utils/* .
 COPY ./static/* . 

--- a/dockerfile
+++ b/dockerfile
@@ -80,7 +80,12 @@ WORKDIR /notebooks
 COPY start.sh .
 COPY log_viewer.py . 
 COPY download_models.py .
-COPY ./constants ./dto ./static ./workers ./utils ./templates ./
+COPY ./constants/ ./constants/
+COPY ./dto/ ./dto/
+COPY ./static/ ./static/
+COPY ./workers/ ./workers/
+COPY ./utils/ ./utils/
+COPY ./templates/ ./templates/
 
 RUN ls -la
 

--- a/dockerfile
+++ b/dockerfile
@@ -73,18 +73,22 @@ RUN apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Create workspace directory
 RUN mkdir -p /workspace
-RUN mkdir -p /notebooks
+RUN mkdir -p /notebooks /notebooks/dto /notebooks/static /notebooks/utils /notebooks/workers
 
 # Copy scripts to root
 WORKDIR /notebooks
 COPY start.sh .
 COPY log_viewer.py . 
 COPY download_models.py .
-COPY ./workers/* .
-COPY ./utils/* .
-COPY ./static/* . 
-COPY ./dto/* . 
-COPY ./constants/* .
+COPY ./constants/* ./constants
+COPY ./dto/* ./dto
+COPY ./static/* ./static
+COPY ./workers/* ./workers
+COPY ./utils/* ./utils
+
+
+
+COPY ./templates/* ./templates
 
 COPY models_config.json /workspace
 

--- a/dockerfile
+++ b/dockerfile
@@ -80,15 +80,9 @@ WORKDIR /notebooks
 COPY start.sh .
 COPY log_viewer.py . 
 COPY download_models.py .
-COPY ./constants/* ./constants
-COPY ./dto/* ./dto
-COPY ./static/* ./static
-COPY ./workers/* ./workers
-COPY ./utils/* ./utils
+COPY ./constants ./dto ./static ./workers ./utils ./templates ./
 
-
-
-COPY ./templates/* ./templates
+RUN ls -la
 
 COPY models_config.json /workspace
 

--- a/download_models.py
+++ b/download_models.py
@@ -207,7 +207,7 @@ async def track_download_progress(
 async def main():
     """Main async function to download models concurrently"""
     # Environment variables
-    config_path = os.getenv("MODELS_CONFIG_URL", "./models_config.json")
+    config_path = os.getenv("MODELS_CONFIG_URL", "/workspace/models_config.json")
     skip_download = os.getenv("SKIP_MODEL_DOWNLOAD", "").lower() == "true"
     force_download = os.getenv("FORCE_MODEL_DOWNLOAD", "").lower() == "true"
 
@@ -217,7 +217,7 @@ async def main():
         return
 
     # Check if ComfyUI is fully set up
-    comfyui_path = "./ComfyUI"
+    comfyui_path = "/workspace/ComfyUI"
     if not os.path.exists(os.path.join(comfyui_path, "main.py")) and (not force_download):
         logger.info(
             "ComfyUI main.py not found. Skipping model downloads until ComfyUI is installed."
@@ -239,7 +239,7 @@ async def main():
             return
 
     # Base path for ComfyUI
-    base_path = Path("./ComfyUI")
+    base_path = Path("/workspace/ComfyUI")
 
     # Ensure directories exist
     ensure_directories(base_path)
@@ -269,9 +269,9 @@ async def main():
                 "style_models": [],
             }
             logger.info("Using default empty configuration")
-            with open("./models_config.json", "w") as f:
+            with open("/workspace/models_config.json", "w") as f:
                 json.dump(default_config, f, indent=4)
-            config_path = "./models_config.json"
+            config_path = "/workspace/models_config.json"
 
     # Fetch configuration
     config = await get_config_async(config_path)

--- a/download_models.py
+++ b/download_models.py
@@ -45,9 +45,9 @@ async def download_file(
             "--console-log-level=warn",  # Reduce verbosity to warnings only
             "-c",  # Continue downloading if partial file exists
             "-x",
-            "16",  # Increase concurrent connections to 16
+            "4",  # Increase concurrent connections to 4
             "-s",
-            "16",  # Split file into 16 parts
+            "4",  # Split file into 4 parts
             "-k",
             "1M",  # Minimum split size
             "--file-allocation=none",  # Disable file allocation for faster start

--- a/download_models.py
+++ b/download_models.py
@@ -11,7 +11,7 @@ from typing import List, Dict, Any
 logging.getLogger().handlers = []
 
 # Set up logging to file only, since stdout is already captured by tee in start.sh
-log_file_path = "./logs/comfyui.log"
+log_file_path = "./logs/download.log"
 file_handler = logging.FileHandler(log_file_path, encoding="utf-8")
 file_handler.setFormatter(
     logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
@@ -24,7 +24,7 @@ logger.addHandler(file_handler)
 # Also log to stdout for visibility
 stdout_handler = logging.StreamHandler(sys.stdout)
 stdout_handler.setFormatter(
-    logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    logging.Formatter("%(message)s")
 )
 logger.addHandler(stdout_handler)
 

--- a/download_models.py
+++ b/download_models.py
@@ -11,10 +11,10 @@ from typing import List, Dict, Any
 logging.getLogger().handlers = []
 
 # Set up logging to file only, since stdout is already captured by tee in start.sh
-log_file_path = "./logs/download.log"
+log_file_path = "/workspace/logs/comfyui.log"
 file_handler = logging.FileHandler(log_file_path, encoding="utf-8")
 file_handler.setFormatter(
-    logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    logging.Formatter("%(message)s")
 )
 
 logger = logging.getLogger(__name__)

--- a/start.sh
+++ b/start.sh
@@ -285,7 +285,7 @@ if [ -n "$CONFIG_FILE" ] && [ -f "$CONFIG_FILE" ]; then
     # Download models if any are missing and downloads aren't skipped
     if [ "$missing_models" = true ] && [ "$SKIP_MODEL_DOWNLOAD" != "true" ]; then
         echo "Some required models are missing. Downloading models..." | tee -a /workspace/logs/comfyui.log
-        python ./download_models.py 2>&1 | tee -a $LOG_PATH
+        python /notebooks/download_models.py 2>&1 | tee -a $LOG_PATH
     else
         echo "All required models present or download skipped..." | tee -a /workspace/logs/comfyui.log
     fi

--- a/start.sh
+++ b/start.sh
@@ -6,7 +6,7 @@ export UPDATE_ON_START=${UPDATE_ON_START:-"false"}
 export MODELS_CONFIG_URL=${MODELS_CONFIG_URL:-"https://raw.githubusercontent.com/poomshift/comfyui-docker-new/refs/heads/main/models_config.json"}
 export SKIP_MODEL_DOWNLOAD=${SKIP_MODEL_DOWNLOAD:-"false"}
 export FORCE_MODEL_DOWNLOAD=${FORCE_MODEL_DOWNLOAD:-"false"}
-export LOG_PATH=${LOG_PATH:-"/workspace/backend.log"}
+export LOG_PATH=${LOG_PATH:-"/notebooks/backend.log"}
 
 export TORCH_FORCE_WEIGHTS_ONLY_LOAD=1
 
@@ -79,9 +79,9 @@ clean_log_file() {
 clean_log_file
 
 # Start log viewer early to monitor the installation process
-cd /workspace
+cd /notebooks
 # CUDA_VISIBLE_DEVICES="" python /log_viewer.py &
-CUDA_VISIBLE_DEVICES="" nohup python ./log_viewer.py &>$LOG_PATH &
+CUDA_VISIBLE_DEVICES="" nohup python /notebooks/log_viewer.py &>$LOG_PATH &
 echo "Started log viewer on port 8189 - Monitor setup at http://localhost:8189"
 cd /
 

--- a/workers/tailLogsFile.py
+++ b/workers/tailLogsFile.py
@@ -9,10 +9,10 @@ from utils.formatLogLine import format_log_line
 
 def tail_log_file():
     """Continuously tail the log file and update the buffer"""
-    log_file = os.path.join("workspace","logs", "comfyui.log")
+    log_file = os.path.join("/", "workspace", "logs", "comfyui.log")
 
     if not os.path.exists(log_file):
-        os.makedirs("workspace","logs", exist_ok=True)
+        os.makedirs("/","workspace","logs", exist_ok=True)
         open(log_file, "a").close()
 
     def follow(file_path):

--- a/workers/tailLogsFile.py
+++ b/workers/tailLogsFile.py
@@ -9,10 +9,10 @@ from utils.formatLogLine import format_log_line
 
 def tail_log_file():
     """Continuously tail the log file and update the buffer"""
-    log_file = os.path.join("logs", "comfyui.log")
+    log_file = os.path.join("workspace","logs", "comfyui.log")
 
     if not os.path.exists(log_file):
-        os.makedirs("logs", exist_ok=True)
+        os.makedirs("workspace","logs", exist_ok=True)
         open(log_file, "a").close()
 
     def follow(file_path):


### PR DESCRIPTION
จากที่พบปัญหาว่า template นี้ใน Runpod ไม่สามารถใช้งานกับ secure cloud ได้เนื่องจากหาไฟล์ start.sh ไม่เจอ โดย pull request นี้มีการจัดไฟล์ให้ตัวเว็บ log viewer และ start.sh ไปอยู่ที่ `/notebooks` แทน `/workspace` เพราะว่า `/workspace` ถูกสร้างขึ้นทีหลังหรือถูกเขียนทับเนื่องจาก network drive ของทาง runpod 

## ทำไมถึงเกิดขึ้น ?

เพราะว่า secure cloud ใช้ network volume อยู่คนละที่คล้าย ๆ กับ NAS ทำให้มีความเร็วช้ากว่า disk ใน community cloud และมีการเขียนทับด้วย ทำให้ต้องย้าย script และ API เรียก website ไปที่ `/notebooks` ทั้งหมด 

## ไฟล์ที่ถูกแก้ไข 

- Dockerfile
- download_models.py
- start.sh
- workers/tailLogsFile.py

โดยการแก้คือแก้การ copy ไฟล์และ path ทั้งหมดให้เป็น absolute path แทน